### PR TITLE
Add tempest to disabled services

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -56,7 +56,8 @@ runs:
         EOF
         # horizon does not work in github action, permission error
         # dstat log takes too much memory to be stored by log artifacts
-        ENABLED_SERVICES=",-horizon,-dstat"
+        # tempest must be disabled otherwise it will get installed still
+        ENABLED_SERVICES=",-horizon,-dstat,-tempest"
         if [[ "${{ inputs.enabled_services }}" != "" ]]; then
           ENABLED_SERVICES+=",${{ inputs.enabled_services }}"
         fi


### PR DESCRIPTION
Devstack does not respect the `INSTALL_TEMPEST=False` setting and still
tries to install tempest when it is found in the ENABLED_SERVICES
variable. We need to remove it from the list in order to ensure it won't
be installed.

See https://github.com/gophercloud/gophercloud/issues/2408 for more
info.