### PR TITLE
Use github mirrors by default

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -57,6 +57,7 @@ runs:
         LOGFILE=${{ inputs.log_dir }}/devstack.log
         USE_PYTHON3=True
         INSTALL_TEMPEST=False
+        GIT_BASE=https://github.com
         EOF
         # horizon does not work in github action, permission error
         # dstat log takes too much memory to be stored by log artifacts


### PR DESCRIPTION
The github action runs on github infra, we should use github mirrors.

This setting can be changed back to opendev.org by setting an override like this:

    conf_overrides: |
      GIT_BASE=https://opendev.org