### PR TITLE
Add force option to allow running devstack on unsupported distro

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -16,6 +16,9 @@ inputs:
   enable_workaround_docker_io:
     description: 'Enable or disable workaround for docker.io'
     default: 'true'
+  force:
+    description: 'Allow running devstack on unsupported distro'
+    default: 'no'
 runs:
   using: "composite"
   steps:
@@ -73,6 +76,8 @@ runs:
       working-directory: ./devstack
       shell: bash
     - name: Run devstack
+      env:
+        FORCE: ${{ inputs.force }}
       run: ./stack.sh
       working-directory: ./devstack
       shell: bash


### PR DESCRIPTION
By setting `force: "yes"` when calling devstack-action, this allows running devstack on unsupported distros. This is especially useful now that github retires the Ubuntu 18.04 runner.

https://opendev.org/openstack/devstack/src/commit/ab8e51eb49/stack.sh#L230-L239