### PR TITLE
Ensure Upgrade in action

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -22,6 +22,9 @@ inputs:
 runs:
   using: "composite"
   steps:
+    - name: Run update and upgrade
+      run: sudo apt update && sudo apt -y upgrade
+      shell: bash
     - name: Install python pip
       run: python -m pip install --upgrade pip
       shell: bash


### PR DESCRIPTION
Baremetal jobs were failling because of dpkg failed to process the grub-efi-amd64-signed package, according to some articles online, we can avoid this problem by ensuring we have the latest packages installed.

https://askubuntu.com/questions/1276111/error-upgrading-grub-efi-amd64-signed-special-device-old-ssd-does-not-exist https://forum.hestiacp.com/t/ubuntu-20-04-installation-error/4323