### PR TITLE
Bump versions of actions

### DIFF
--- a/.github/workflows/with-defaults.yml
+++ b/.github/workflows/with-defaults.yml
@@ -7,12 +7,12 @@ jobs:
     runs-on: ubuntu-latest
     name: A job to deploy devstack with defaults
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - id: devstack-action
         uses: ./
       - name: Upload logs artifacts on failure
         if: failure()
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: devstack-logs
           path: /tmp/devstack-logs/*

--- a/action.yaml
+++ b/action.yaml
@@ -43,7 +43,7 @@ runs:
       run: sudo apt-get purge -y python3-simplejson python3-pyasn1-modules postgresql* || true
       shell: bash
     - name: Checkout Devstack
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
       with:
         ref: ${{ inputs.branch }}
         repository: openstack/devstack


### PR DESCRIPTION
@EmilienM this is to fix:
>Node.js 16 actions are deprecated. Please update the following actions to use Node.js 20: actions/checkout@v3. For more information see: https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/.

new release would be useful