### PR TITLE
Don't require to shell-escape conf_overrides

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -81,9 +81,9 @@ runs:
         echo "ENABLED_SERVICES+=${ENABLED_SERVICES}" >> local.conf
 
         # This must stay at the end to allow any overrides
-        if [[ "${{ inputs.conf_overrides }}" != "" ]]; then
-          echo "${{ inputs.conf_overrides }}" >> local.conf
-        fi
+        cat << EOF_CONF_OVERRIDES >> local.conf
+        ${{ inputs.conf_overrides }}
+        EOF_CONF_OVERRIDES
       working-directory: ./devstack
       shell: bash
     - name: Run devstack


### PR DESCRIPTION
Use heredoc syntax to append the value of `conf_overrides` to the `local.conf` file. Compared to the previous solution using `echo`, this removes the need to shell escape your value.

Also remove the useless test, since the default value for `inputs.conf_overrides` is an empty string which results in a noop.

Fixes #19.