### PR TITLE
chore: switch to python3

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -23,7 +23,7 @@ runs:
   using: "composite"
   steps:
     - name: Install python pip
-      run: python -m pip install --upgrade pip
+      run: python3 -m pip install --upgrade pip
       shell: bash
     - name: Erase MySQL package
       run: sudo apt-get purge mysql-* || true


### PR DESCRIPTION
When using self-hosted runners, `python` might not actually call `python3` and just give an error, so we can swap to this.