### PR TITLE
fix unaccountable leading "-e" in /etc/hosts

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -31,8 +31,10 @@ runs:
     # This is to avoid RabbitMQ to fail at startup because a wrong version of erlang was installed
     - name: Workaround for RabbitMQ
       run: |
+        # fix freaky leading "-e" in /etc/hosts
+        sudo sed -i 's/^-e \+//g' /etc/hosts
         sudo apt-get purge -y esl-erlang || true
-        sudo apt-get install -y erlang rabbitmq-server || true
+        sudo apt-get install -y erlang rabbitmq-server # if rabbitmq-server is not installed, tests must be stopped
       shell: bash
     - name: Workaround for docker.io
       if: ${{ inputs.enable_workaround_docker_io == 'true' }}


### PR DESCRIPTION
@stephenfin 

```
$ sudo cat /etc/hosts
127.0.0.1 localhost

# The following lines are desirable for IPv6 capable hosts
::1     localhost ip6-localhost ip6-loopback
fe00::0 ip6-localnet
ff00::0 ip6-mcastprefix
ff02::1 ip6-allnodes
ff02::2 ip6-allrouters
ff02::3 ip6-allhosts
-e 10.1.0.192 pkrvmwou917u6c3.vluyefalokqupermxzuhduojkb.gx.internal.cloudapp.net pkrvmwou917u6c3
```

wth? may it be the broken azure VM automation?

UPD: yes, see https://github.com/actions/runner-images/issues/12192