### PR TITLE
Dump local.conf

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -81,6 +81,11 @@ runs:
         EOF_CONF_OVERRIDES
       working-directory: ./devstack
       shell: bash
+    - name: Dump local.conf
+      run: |
+        cat local.conf
+      working-directory: ./devstack
+      shell: bash
     - name: Run devstack
       env:
         FORCE: ${{ inputs.force }}

--- a/action.yaml
+++ b/action.yaml
@@ -61,7 +61,6 @@ runs:
         SERVICE_PASSWORD=secret
         SWIFT_HASH=1234123412341234
         LOGFILE=${{ inputs.log_dir }}/devstack.log
-        USE_PYTHON3=True
         INSTALL_TEMPEST=False
         GIT_BASE=https://github.com
         EOF


### PR DESCRIPTION
This is helpful if you are attempting to reproduce builds locally. Given we use well-known usernames and passwords, this should not expose anything secret.
