### PR TITLE
preliminarily update the apt cache

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -25,8 +25,11 @@ runs:
     - name: Install python pip
       run: python3 -m pip install --upgrade pip
       shell: bash
+    - name: Update APT cache
+      run: sudo apt-get update
+      shell: bash
     - name: Erase MySQL package
-      run: sudo apt-get purge mysql-* || true
+      run: sudo apt-get purge -y mysql-* || true
       shell: bash
     # This is to avoid RabbitMQ to fail at startup because a wrong version of erlang was installed
     - name: Workaround for RabbitMQ


### PR DESCRIPTION
Fix issues like:
```
E: Failed to fetch mirror+file:/etc/apt/apt-mirrors.txt/pool/main/libv/libvpx/libvpx7_1.11.0-2ubuntu2.3_amd64.deb  404  Not Found [IP: 52.147.219.192 80]
E: Unable to fetch some archives, maybe run apt-get update or try with --fix-missing?
```